### PR TITLE
Make todo list link point to local file

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
             </div>
           </div>
           </a>
-          <a href="https://travellerentity.xyz/javascripts/todolist" class="link-no-decoration"><div class="flex-projects-item">
+          <a href="/javascripts/todolist" class="link-no-decoration"><div class="flex-projects-item">
             <div class="flex-project-image-container">
               <img src="assets/png/todolist.png" class="flex-project-image" />
             </div>


### PR DESCRIPTION
The To-Do list card wasn't pointing to the  directory on the web server. Instead it was formatted like a link to an external webpage, which made the development site redirect to the live one.